### PR TITLE
Added templates to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include dlhub-cli/commands/init_templates *.template

--- a/dlhub_cli/version.py
+++ b/dlhub_cli/version.py
@@ -1,6 +1,6 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # app name to send as part of SDK requests
 app_name = "DLHub CLI v{}".format(__version__)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ version = version_ns['__version__']
 setup(
     name="dlhub_cli",
     version=version,
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    packages=find_packages(exclude=['tests', 'tests.*']) + ['dlhub_cli.commands.init_templates'],
     install_requires=[
         'click>=6.6,<7.0',
         'requests>=2.0.0,<3.0.0',
@@ -19,7 +19,9 @@ setup(
     entry_points={
         'console_scripts': ['dlhub = dlhub_cli:cli_root']
     },
-
+    package_data={
+        'dlhub_cli.commands.init_templates': ['*.template']
+    },
     # descriptive info, non-critical
     description="DLHub CLI",
     long_description=open("README.md").read(),


### PR DESCRIPTION
As pointed out by Max, we forgot to include needed template files in our PyPi distribution. 

This PR fixes that problem by adding a manifest and altering setup.py